### PR TITLE
Added translation of code-of-conduct to Brazilian Portuguese

### DIFF
--- a/code-of-conduct-PT.md
+++ b/code-of-conduct-PT.md
@@ -2,9 +2,9 @@
 
 Nós estamos dedicados a prover uma experiência livre de assédio para todos e não toleramos assédio dos participantes em qualquer forma. Nós pedimos a você que seja atencioso com os outros, se comporte profissionalmente e respeitosamente à todos outros participantes. Este código e procedimento relacionados também são aplicados para comportamento inaceitáveis que ocorram fora do escopo das atividades da comunidade, em todos locais da comunidade online e pessoalmente, bem como em toda comunicação individual e onde tal comportamento tenha potencial de prejudicar a segurança e o bem estar dos membros da comunidade. Exibidores, palestrantes, patrocinadores, staff e todos os outros participantes em eventos organizados pela Docker, Inc (DockerCon, meetups, grupo de usuários) ou mantidos em instalações Docker Inc. estão sujeitos a estas Diretrizes e Código de Conduta da Comunidade.
 
-Diversidade e inclusão faz comunidade Docker forte. Nós encorajamos a participação a maior variedade e diversidade possível, queremos ser bem claro onde estamos.
+Diversidade e inclusão tornam a comunidade Docker forte. Nós encorajamos a participação a maior variedade e diversidade possível, queremos ser bem claro onde estamos.
 
-Nosso objetivo é manter uma comunidade Docker amigável, útil e segura para todos, independente da experiência, identidade e expressão de gênero, orientação sexual, deficiência, aparência pessoal, tamanho do corpo, raça, etnia, idade, religião, nacionalidade ou qualquer categoria protegida nos termos da lei.
+Nosso objetivo é manter uma comunidade Docker amigável, útil e segura para todos, independente da experiência, identidade e expressão de gênero, orientação sexual, deficiência, aparência pessoal, tamanho, raça, etnia, idade, religião, nacionalidade ou qualquer categoria protegida nos termos da lei.
 
 ##Expectativa de comportamento
 
@@ -12,15 +12,15 @@ Nosso objetivo é manter uma comunidade Docker amigável, útil e segura para to
 - Ser responsável.
 - Ser receptivo.
 - Ser gentil.
-- Ser respeitoso ao outros pontos de vista e ideias.
-- Ser solidário e respeitoso um com outro.
+- Respeitar o ponto de vista dos outros e ideais diferentes.
+- Ser solidário e respeitoso o próximo.
 
 ##Comportamento não esperado
 
 Assédio pode incluir a lista abaixo mas não limitado à ela:
 
 - Comentários ofensivos, inadequados ou indesejáveis ao gênero, orientação sexual, deficiência, aparência física, tamanho do corpo, raça, etnia, nacionalidade, religião, idade ou qualquer outra categoria protegida pela lei.
-- Assédio visual, ex: imagens sexual ou uso de linguagem sexual nos eventos da comunidade Docker
+- Assédio visual, ex: imagens sexuais ou uso de linguagem sexual nos eventos da comunidade Docker
 - Desrespeito às diferentes opiniões
 - Intimidação deliberada, perseguição, gravação ou fotografia constrangedoras
 - Interrupção continua das palestras ou outros eventos
@@ -30,7 +30,7 @@ Assédio pode incluir a lista abaixo mas não limitado à ela:
 
 ##Relatórios e Aplicação
 
-- Se você sofrer ou testemunhar qualquer violação do Código de Conduta, por favor, entre me contato conosco pelo relatório de incidente (inglês) [incident report](https://docs.google.com/forms/d/e/1FAIpQLScezna1ZXRPzC_phSDoPEF4c5nvw8yQW-vvtI8xHjv-BB9MOg/viewform?c=0&w=1), ou poremail dockercon@docker.com
+- Se você sofrer ou testemunhar qualquer violação do Código de Conduta, por favor, entre em contato conosco pelo relatório de incidentes (inglês) [incident report](https://docs.google.com/forms/d/e/1FAIpQLScezna1ZXRPzC_phSDoPEF4c5nvw8yQW-vvtI8xHjv-BB9MOg/viewform?c=0&w=1), ou por email dockercon@docker.com
 - Se necessário, staff da conferência poderão tomar as ações apropriadas, não limitado a elas, advertir, expulsar da conferência sem reembolso e encaminhar para segurança do local ou autoridade local.
 
 Texto baseado nos [Slack Developer Community Code of Conduct](https://api.slack.com/docs/community-code-of-conduct), [The Ada Initiative](https://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/), [geekfeminism.org](https://geekfeminism.org/about/code-of-conduct/) e [Drupal Events Code of Conduct](https://events.drupal.org/dublin2016/code-conduct)

--- a/codigo-de-conduta.md
+++ b/codigo-de-conduta.md
@@ -1,0 +1,40 @@
+##Introdução
+
+Nós estamos dedicados a prover uma experiência livre de assédio para todos e não toleramos assédio dos participantes em qualquer forma. Nós pedimos a você que seja atencioso com os outros, se comporte profissionalmente e respeitosamente à todos outros participantes. Este código e procedimento relacionados também são aplicados para comportamento inaceitáveis que ocorram fora do escopo das atividades da comunidade, em todos locais da comunidade online e pessoalmente, bem como em toda comunicação individual e onde tal comportamento tenha potencial de prejudicar a segurança e o bem estar dos membros da comunidade. Exibidores, palestrantes, patrocinadores, staff e todos os outros participantes em eventos organizados pela Docker, Inc (DockerCon, meetups, grupo de usuários) ou mantidos em instalações Docker Inc. estão sujeitos a estas Diretrizes e Código de Conduta da Comunidade.
+
+Diversidade e inclusão faz comunidade Docker forte. Nós encorajamos a participação a maior variedade e diversidade possível, queremos ser bem claro onde estamos.
+
+Nosso objetivo é manter uma comunidade Docker amigável, útil e segura para todos, independente da experiência, identidade e expressão de gênero, orientação sexual, deficiência, aparência pessoal, tamanho do corpo, raça, etnia, idade, religião, nacionalidade ou qualquer categoria protegida nos termos da lei.
+
+##Expectativa de comportamento
+
+- Ser profissional.
+- Ser responsável.
+- Ser receptivo.
+- Ser gentil.
+- Ser respeitoso ao outros pontos de vista e ideias.
+- Ser solidário e respeitoso um com outro.
+
+##Comportamento não esperado
+
+Assédio pode incluir a lista abaixo mas não limitado à ela:
+
+- Comentários ofensivos, inadequados ou indesejáveis ao gênero, orientação sexual, deficiência, aparência física, tamanho do corpo, raça, etnia, nacionalidade, religião, idade ou qualquer outra categoria protegida pela lei.
+- Assédio visual, ex: imagens sexual ou uso de linguagem sexual nos eventos da comunidade Docker
+- Desrespeito às diferentes opiniões
+- Intimidação deliberada, perseguição, gravação ou fotografia constrangedoras
+- Interrupção continua das palestras ou outros eventos
+- Contato físico inapropriado ou indesejado
+- Intimidação ou bullying (online ou pessoalmente)
+- Atenção sexual não desejada
+
+##Relatórios e Aplicação
+
+- Se você sofrer ou testemunhar qualquer violação do Código de Conduta, por favor, entre me contato conosco pelo relatório de incidente (inglês) [incident report](https://docs.google.com/forms/d/e/1FAIpQLScezna1ZXRPzC_phSDoPEF4c5nvw8yQW-vvtI8xHjv-BB9MOg/viewform?c=0&w=1), ou poremail dockercon@docker.com
+- Se necessário, staff da conferência poderão tomar as ações apropriadas, não limitado a elas, advertir, expulsar da conferência sem reembolso e encaminhar para segurança do local ou autoridade local.
+
+Texto baseado nos [Slack Developer Community Code of Conduct](https://api.slack.com/docs/community-code-of-conduct), [The Ada Initiative](https://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/), [geekfeminism.org](https://geekfeminism.org/about/code-of-conduct/) e [Drupal Events Code of Conduct](https://events.drupal.org/dublin2016/code-conduct)
+
+Este documento está licenciado como Creative Commons Attribution 3.0 Unported License For attribution requirements:
+
+"@Docker Code of Conduct" © 2016 Docker, Inc, used under a Creative Commons Attribution Unported license: [http://creativecommons.org/licenses/by/3.0/](http://creativecommons.org/licenses/by/3.0/)


### PR DESCRIPTION
I would like to use this translation to Docker Sao Paulo meetup as code of conduct. But, I think this is could be useful to any meetups to speak in portuguese.

