### PR TITLE
chore: update reporting email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker Code of Conduct
 
-This repository contains the Docker, Inc. Open Source [Code of Conduct](code-of-conduct-EN.md), used at DockerCon and other events, meetups, and user groups.
+This repository contains the Docker, Inc. Open Source [Code of Conduct](code-of-conduct-EN.md), used for open source projects, DockerCon and other events, meetups, and user groups.
 
 # License
 

--- a/code-of-conduct-EN.md
+++ b/code-of-conduct-EN.md
@@ -30,7 +30,7 @@ Harassment may include but not limited to the following:
 
 ## Reporting and Enforcement
 
-- If you are the subject of, or witness to any violations of this Code of Conduct, please contact us by submitting an [incident report](https://docs.google.com/forms/d/e/1FAIpQLScezna1ZXRPzC_phSDoPEF4c5nvw8yQW-vvtI8xHjv-BB9MOg/viewform?c=0&w=1), or email dockercon@docker.com
+- If you are the subject of, or witness to any violations of this Code of Conduct, please contact us by submitting an [incident report](https://docs.google.com/forms/d/e/1FAIpQLScezna1ZXRPzC_phSDoPEF4c5nvw8yQW-vvtI8xHjv-BB9MOg/viewform?c=0&w=1), or email conduct@docker.com
 - If necessary, conference staff are empowered to take appropriate actions that may include, but are not limited to, warnings, expulsion from the conference without refund, and referrals to venue security or local law enforcement.
 
 Portions derived from the [Slack Developer Community Code of Conduct](https://api.slack.com/docs/community-code-of-conduct), [The Ada Initiative](https://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/), [geekfeminism.org](https://geekfeminism.org/about/code-of-conduct/) and [Drupal Events Code of Conduct](https://events.drupal.org/dublin2016/code-conduct)

--- a/code-of-conduct-ES.md
+++ b/code-of-conduct-ES.md
@@ -33,7 +33,7 @@ El acoso puede incluir, pero no limitarse, lo siguiente:
 
 ## Información y ejecución
 
-- Si eres sujeto o testigo de alguna violación de este código de conducta, por favor contáctanos presentando un informe de incidencias[incident report](https://docs.google.com/forms/d/e/1FAIpQLScezna1ZXRPzC_phSDoPEF4c5nvw8yQW-vvtI8xHjv-BB9MOg/viewform?c=0&w=1), o enviando un correo electrónico a dockercon@docker.com
+- Si eres sujeto o testigo de alguna violación de este código de conducta, por favor contáctanos presentando un informe de incidencias[incident report](https://docs.google.com/forms/d/e/1FAIpQLScezna1ZXRPzC_phSDoPEF4c5nvw8yQW-vvtI8xHjv-BB9MOg/viewform?c=0&w=1), o enviando un correo electrónico a conduct@docker.com
 - Si fuera necesario, el personal de conferencias está capacitado para llevar acabo las acciones necesarias, las cuales pueden incluir, pero no limitarse a: advertencias, expulsión de la conferencia sin posibilidad de reembolso, y remisión a la seguridad de los locales y aplicación de la ley.
 
 Texto basado en [Slack Developer Community Code of Conduct](https://api.slack.com/docs/community-code-of-conduct), [The Ada Initiative](https://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/), [geekfeminism.org](https://geekfeminism.org/about/code-of-conduct/) y [Drupal Events Code of Conduct](https://events.drupal.org/dublin2016/code-conduct)

--- a/code-of-conduct-ID.md
+++ b/code-of-conduct-ID.md
@@ -30,7 +30,7 @@ Pelecehan dapat mencakup namun tidak terbatas pada hal berikut:
 
 ## Pelaporan dan Penegakan
 
-- Jika Anda adalah korban atau saksi atas pelanggaran Kode Etik ini, silakan hubungi kami dengan mengirimkan [incident report](https://docs.google.com/forms/d/e/1FAIpQLScezna1ZXRPzC_phSDoPEF4c5nvw8yQW-vvtI8xHjv-BB9MOg/viewform?c=0&w=1)  atau surat elektronik dockercon@docker.com
+- Jika Anda adalah korban atau saksi atas pelanggaran Kode Etik ini, silakan hubungi kami dengan mengirimkan [incident report](https://docs.google.com/forms/d/e/1FAIpQLScezna1ZXRPzC_phSDoPEF4c5nvw8yQW-vvtI8xHjv-BB9MOg/viewform?c=0&w=1)  atau surat elektronik conduct@docker.com
 - Bila perlu, staf konferensi diberi wewenang untuk melakukan tindakan yang mungkin termasuk, namun tidak terbatas pada, peringatan, pengusiran dari konferensi tanpa pengembalian dana, dan rujukan ke tempat keamanan atau penegak hukum setempat.
 
 Bagian ini berasal dari [Slack Developer Community Code of Conduct](https://api.slack.com/docs/community-code-of-conduct), [The Ada Initiative](https://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/), [geekfeminism.org](https://geekfeminism.org/about/code-of-conduct/) dan [Drupal Events Code of Conduct](https://events.drupal.org/dublin2016/code-conduct)

--- a/code-of-conduct-IT.md
+++ b/code-of-conduct-IT.md
@@ -30,7 +30,7 @@ Questa è la lista non esaustiva delle possibili molestie:
 
 ## Denuncia e azioni di contrasto
 
-- Se sei oggetto o testimone di qualsiasi violazione di questo Codice di condotta, ti preghiamo di contattaci inviandoci un [resoconto dell'incidente](https://docs.google.com/forms/d/e/1FAIpQLScezna1ZXRPzC_phSDoPEF4c5nvw8yQW-vvtI8xHjv-BB9MOg/viewform?c=0&w=1), o scrivici all'indirizzo email dockercon@docker.com.
+- Se sei oggetto o testimone di qualsiasi violazione di questo Codice di condotta, ti preghiamo di contattaci inviandoci un [resoconto dell'incidente](https://docs.google.com/forms/d/e/1FAIpQLScezna1ZXRPzC_phSDoPEF4c5nvw8yQW-vvtI8xHjv-BB9MOg/viewform?c=0&w=1), o scrivici all'indirizzo email conduct@docker.com.
 - Se necessario, il personale della conferenza conferenza è autorizzato ad adottare le azioni appropriate che includono, tra le altre, avvisi, espulsioni dalla conferenza senza diritto al rimborso e denuncia alla sicurezza del luogo e/o alle forze dell'ordine.
 
 Questo codice basato sul [Codice di condotta degli sviluppatori di Slack](https://api.slack.com/docs/community-code-of-conduct), [The Ada Initiative](https://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/), [geekfeminism.org](https://geekfeminism.org/about/code-of-conduct/) e sul [Codice di condotta degli eventi di Drupal](https://events.drupal.org/dublin2016/code-conduct).

--- a/code-of-conduct-JP.md
+++ b/code-of-conduct-JP.md
@@ -30,7 +30,7 @@
 - 性的嫌がらせ
 
 ## 報告及び執行
-- この行為規範に反する行為を目撃、または自身が被害に遭った場合、[被害届](https://docs.google.com/forms/d/e/1FAIpQLScezna1ZXRPzC_phSDoPEF4c5nvw8yQW-vvtI8xHjv-BB9MOg/viewform?c=0&w=1)もしくは dockercon@docker.com のメールを通じ連絡を行ってください。
+- この行為規範に反する行為を目撃、または自身が被害に遭った場合、[被害届](https://docs.google.com/forms/d/e/1FAIpQLScezna1ZXRPzC_phSDoPEF4c5nvw8yQW-vvtI8xHjv-BB9MOg/viewform?c=0&w=1)もしくは conduct@docker.com のメールを通じ連絡を行ってください。
 - 必要の場合、会議のスタッフには警告、参加費返済なしの会議からの追放、または現地のセキュリティないし現地警察当局への委託などの適切な行動を取る権限が与えられています。
 
 Portions derived from the [Slack Developer Community Code of Conduct](https://api.slack.com/docs/community-code-of-conduct), [The Ada Initiative](https://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/), [geekfeminism.org](https://geekfeminism.org/about/code-of-conduct/) and [Drupal Events Code of Conduct](https://events.drupal.org/dublin2016/code-conduct)

--- a/code-of-conduct-PT.md
+++ b/code-of-conduct-PT.md
@@ -30,7 +30,7 @@ Assédio pode incluir a lista abaixo mas não limitado à ela:
 
 ## Relatórios e Aplicação
 
-- Se você sofrer ou testemunhar qualquer violação do Código de Conduta, por favor, entre em contato conosco pelo relatório de incidentes (inglês) [incident report](https://docs.google.com/forms/d/e/1FAIpQLScezna1ZXRPzC_phSDoPEF4c5nvw8yQW-vvtI8xHjv-BB9MOg/viewform?c=0&w=1), ou por email dockercon@docker.com
+- Se você sofrer ou testemunhar qualquer violação do Código de Conduta, por favor, entre em contato conosco pelo relatório de incidentes (inglês) [incident report](https://docs.google.com/forms/d/e/1FAIpQLScezna1ZXRPzC_phSDoPEF4c5nvw8yQW-vvtI8xHjv-BB9MOg/viewform?c=0&w=1), ou por email conduct@docker.com
 - Se necessário, staff da conferência poderão tomar as ações apropriadas, não limitado a elas, advertir, expulsar da conferência sem reembolso e encaminhar para segurança do local ou autoridade local.
 
 Texto baseado nos [Slack Developer Community Code of Conduct](https://api.slack.com/docs/community-code-of-conduct), [The Ada Initiative](https://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/), [geekfeminism.org](https://geekfeminism.org/about/code-of-conduct/) e [Drupal Events Code of Conduct](https://events.drupal.org/dublin2016/code-conduct)

--- a/code-of-conduct-ZH-Simple.md
+++ b/code-of-conduct-ZH-Simple.md
@@ -30,7 +30,7 @@
 
 ## 报告与强制实施
 
-- 如果你是受害者，或是任何违反准则的目击者，请联系我们。你可以提交[事件报告](https://docs.google.com/forms/d/e/1FAIpQLScezna1ZXRPzC_phSDoPEF4c5nvw8yQW-vvtI8xHjv-BB9MOg/viewform?c=0&w=1)，或发送邮件到dockercon@docker.com
+- 如果你是受害者，或是任何违反准则的目击者，请联系我们。你可以提交[事件报告](https://docs.google.com/forms/d/e/1FAIpQLScezna1ZXRPzC_phSDoPEF4c5nvw8yQW-vvtI8xHjv-BB9MOg/viewform?c=0&w=1)，或发送邮件到conduct@docker.com
 - 如果有必要，会议工作人员有权采取有效应对措施。这些措施包括但不限于：警告，移除出会议并且不给予任何退款，移交会场安全负责单位，或当地执法部门
 
 部分条款摘自[Slack Developer Community Code of Conduct](https://api.slack.com/docs/community-code-of-conduct),[The Ada Initiative](https://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/), [geekfeminism.org](https://geekfeminism.org/about/code-of-conduct/) and [Drupal Events Code of Conduct](https://events.drupal.org/dublin2016/code-conduct)


### PR DESCRIPTION
## summary
- updates reporting email address to conduct@docker.com
- adds open source projects to list of applicability

This is an attempt to partially fix https://github.com/docker/code-of-conduct/issues/34 without invalidating all of the language translations. 
