### PR TITLE
Add Turkish translation of Code of Conduct

### DIFF
--- a/code-of-conduct-TR.md
+++ b/code-of-conduct-TR.md
@@ -1,0 +1,40 @@
+## Giriş
+
+Herkes için uygunsuz davranışlardan arındırılmış bir deneyim sunmaya kararlıyız ve hiçbir biçimde uygunsuz davranışlara tolerans göstermiyoruz. Katılımcıların diğerlerini dikkate almasını, profesyonel ve saygılı davranmasını bekliyoruz. Bu kod ve ilgili prosedürler, topluluk etkinliklerinin kapsamı dışında gerçekleşen uygunsuz davranışlara da uygulanır; tüm topluluk mekânlarında — çevrimiçi ve yüz yüze — ayrıca tüm bire bir iletişimlerde ve bu tür davranışların topluluk üyelerinin güvenliğini ve esenliğini olumsuz etkileme potansiyeline sahip olduğu her yerde geçerlidir. Docker, Inc tarafından düzenlenen etkinliklerde (DockerCon, buluşmalar, kullanıcı grupları) veya Docker, Inc tesislerinde gerçekleştirilen etkinliklerde yer alan katılımcılar, konuşmacılar, sponsorlar, çalışanlar ve diğer tüm katılımcılar bu Topluluk İlkeleri ve Davranış Kuralları’na tabidir.
+
+Çeşitlilik ve kapsayıcılık, Docker topluluğunu güçlü kılar. Olası en farklı ve çeşitli arka plana sahip insanların katılımını teşvik ediyoruz ve bu konudaki duruşumuzu açıkça ortaya koymak istiyoruz.
+
+Amacımız; deneyim düzeyi, cinsiyet kimliği ve ifadesi, cinsel yönelim, engellilik durumu, kişisel görünüm, beden ölçüsü, ırk, etnik köken, yaş, din, milliyet veya yürürlükteki hukuk kapsamında korunan diğer kategoriler fark etmeksizin herkes için güvenli, faydalı ve dostça bir Docker topluluğu sürdürmektir.
+
+## Beklenen Davranışlar
+
+- Profesyonel olun.
+- Sorumluluk sahibi olun.
+- Hoşgörülü olun.
+- Kibar olun.
+- Farklı bakış açılarına ve fikirlere saygılı olun.
+- Birbirinize karşı destekleyici olun ve birbirinizi gözetin.
+
+## Kabul Edilemez Davranışlar
+
+Uygunsuz davranışlar aşağıdakilerle sınırlı olmamak üzere şunları içerebilir:
+
+- Cinsiyet, cinsiyet kimliği veya ifadesi, cinsel yönelim, engellilik, fiziksel görünüm, beden ölçüsü, ırk, etnik köken, milliyet, din, yaş veya yürürlükteki hukuk kapsamında korunan diğer kategorilerle ilgili saldırgan, uygunsuz ya da istenmeyen yorumlar.
+- Görsel taciz; örneğin Docker topluluk etkinliklerinde cinsel içerikli görseller veya cinsel içerikli dil kullanımı.
+- Farklı görüşlere saygısızlık.
+- Tehdit etme, takip etme, rahatsız edici fotoğraf ya da video kaydı.
+- Konuşmaların veya diğer etkinliklerin sürekli biçimde kesintiye uğratılması veya sabote edilmesi.
+- Uygunsuz veya istenmeyen fiziksel temas.
+- Tehdit veya zorbalık (çevrimiçi ya da yüz yüze).
+- İstenmeyen cinsel ilgi.
+
+## Raporlama ve Yaptırım
+
+- Bu Davranış Kuralları’nın herhangi bir ihlalinin mağduruysanız veya tanığıysanız, lütfen bir [olay raporu](https://docs.google.com/forms/d/e/1FAIpQLScezna1ZXRPzC_phSDoPEF4c5nvw8yQW-vvtI8xHjv-BB9MOg/viewform?c=0&w=1) göndererek ya da conduct@docker.com adresine e-posta yazarak bizimle iletişime geçin.
+- Gerekli görüldüğünde konferans personeli; uyarı verme, iade olmaksızın konferanstan çıkarma ve mekân güvenliğine veya yerel kolluk kuvvetlerine yönlendirme dâhil ancak bunlarla sınırlı olmamak üzere uygun önlemleri almaya yetkilidir.
+
+Bu metnin bazı bölümleri [Slack Developer Community Code of Conduct](https://api.slack.com/docs/community-code-of-conduct), [The Ada Initiative](https://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/), [geekfeminism.org](https://geekfeminism.org/about/code-of-conduct/) ve [Drupal Events Code of Conduct](https://events.drupal.org/dublin2016/code-conduct) dokümanlarından alınmıştır.
+
+Bu çalışma, Creative Commons Attribution 3.0 Unported Lisansı ile lisanslanmıştır. Atıf gereksinimleri için:
+
+“@Docker Code of Conduct” © 2016 Docker, Inc, Creative Commons Attribution Unported lisansı kapsamında kullanılmıştır: [http://creativecommons.org/licenses/by/3.0/](http://creativecommons.org/licenses/by/3.0/)


### PR DESCRIPTION
Add a Turkish version of the community Code of Conduct, translated based on the current English version.

No content changes were made, only a localized translation.

Closes #44 